### PR TITLE
BUG: Add runtime dependency on setuptools (Fixes #11)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
     script: python setup.py install --single-version-externally-managed --record record.txt
-    number: 1
+    number: 2
 
 requirements:
   build:
@@ -20,6 +20,7 @@ requirements:
 
   run:
     - python
+    - setuptools
 
 test:
   imports:


### PR DESCRIPTION
It turns out pint imports pkg_resources when running.