### PR TITLE
Fix importing pint's matplotlib support on Python 2.7

### DIFF
--- a/recipe/fix-import.patch
+++ b/recipe/fix-import.patch
@@ -1,0 +1,13 @@
+diff --git a/pint/matplotlib.py b/pint/matplotlib.py
+index d1b543c..bda251d 100644
+--- a/pint/matplotlib.py
++++ b/pint/matplotlib.py
+@@ -9,6 +9,8 @@
+     :copyright: 2017 by Pint Authors, see AUTHORS for more details.
+     :license: BSD, see LICENSE for more details.
+ """
++from __future__ import absolute_import
++
+ import matplotlib.units
+ 
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,12 @@ source:
   fn: {{name}}-{{version}}.tar.gz
   url: https://pypi.io/packages/source/{{name[0]}}/{{name}}/{{name}}-{{version}}.tar.gz
   sha256: {{sha256}}
+  patches:
+    - fix-import.patch  # [py27]
 
 build:
     script: python -m pip install --no-deps --ignore-installed .
-    number: 1
+    number: 2
 
 requirements:
   host:


### PR DESCRIPTION
Needs to enable absolute imports in order to not have conficts when
importing matplotlib from pint's internal matplotlib module.

Fixes conda-forge/metpy-feedstock#27

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
