### PR TITLE
Release 0.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About pint
-==========
+About pint-feedstock
+====================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pint-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/hgrecco/pint
 
 Package license: BSD-3-Clause
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pint-feedstock/blob/main/LICENSE.txt)
 
 Summary: Operate and manipulate physical quantities in Python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/{{ name }}/Pint-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 3e98bdf01f4dcf840cc0207c0b6f7510d4e0c6288efc1bf470626e875c831172
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,9 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 387cf04078dc7dfe4a708033baad54ab61d82ab06c4ee3d4922b1e45d5626067
+  url: https://pypi.io/packages/source/p/{{ name }}/Pint-{{ version }}.tar.gz
+  sha256: 3e98bdf01f4dcf840cc0207c0b6f7510d4e0c6288efc1bf470626e875c831172
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Pint" %}
-{% set version = "0.20.1" %}
+{% set version = "0.21" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
I don't see any relevant changes in the CHANGELOG. The library still supports Python 3.8 so I didn't change that.

https://github.com/hgrecco/pint/blob/ef3a6ec076e5f7730c9e3c8be0356f8967a4efd0/CHANGES

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
